### PR TITLE
Tweak features for chrono dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ version = "1.0"
 
 [dependencies.chrono]
 version = "0.4"
+default-features = false
+features = [ "clock" ]
 
 [dependencies.der]
 version = "0.6"


### PR DESCRIPTION
To work around a security dependency issue as discussed in https://stackoverflow.com/questions/73883691/the-latest-chrono-0-4-crate-uses-time-0-1-which-has-a-potential-segfault-how-t

We will need the `clock` feature of chrono for crate x509-certificate.