### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -12,10 +12,8 @@ jobs:
     runs-on:
       - 'ubuntu-latest'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4.1.1
       - run: |
           set -euxo pipefail
+          cargo --version
           cargo build --release --all-features


### PR DESCRIPTION
Upgrade actions/checkout to v4.1.1 to move away from the now deprecated node 12.

Remove the unmaintained and not-needed actions-rs/toolchain.